### PR TITLE
Include qed from linux-firmware into initramfs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -698,6 +698,7 @@ WORKDIR /initramfs
 COPY --from=squashfs-amd64 /rootfs.sqsh .
 COPY --from=init-build-amd64 /init .
 # copying over firmware binary blobs to initramfs
+COPY --from=pkg-linux-firmware /lib/firmware/qed ./lib/firmware/qed
 COPY --from=pkg-linux-firmware /lib/firmware/bnx2 ./lib/firmware/bnx2
 COPY --from=pkg-linux-firmware /lib/firmware/bnx2x ./lib/firmware/bnx2x
 # the intel ice pkg file from linux-firmware has the version appended to it, but kernel only looks up ice.pkg


### PR DESCRIPTION
# Pull Request

<!--
## Note to the Contributor

We encourage contributors to go through a proposal process to discuss major changes.
Before your PR is allowed to run through CI, the maintainers of Talos will first have to approve the PR.
-->

## What? (description)
Add the qed directory from the linux-firmware package to the talos initramfs.

## Why? (reasoning)
This change is needed to boot/install Talos on baremetal nodes with QLogic based NICs. The linux kernel is unable to load the firmware for the device, and preventing the bring up the interface.


## Acceptance

Please use the following checklist:

- [ ] you linked an issue (if applicable)
- [ ] you included tests (if applicable)
- [ ] you ran conformance (`make conformance`)
- [ ] you formatted your code (`make fmt`)
- [ ] you linted your code (`make lint`)
- [ ] you generated documentation (`make docs`)
- [ ] you ran unit-tests (`make unit-tests`)

> See `make help` for a description of the available targets.
